### PR TITLE
Adapt odoo test for jobrad customization

### DIFF
--- a/odoo/addons/base/tests/test_user_has_group.py
+++ b/odoo/addons/base/tests/test_user_has_group.py
@@ -174,8 +174,11 @@ class TestHasGroup(TransactionCase):
             'groups_id': [(6, 0, [grp_test.id])]
         })
 
-        with self.assertRaises(ValidationError):
-            grp_test.write({'implied_ids': [(4, self.grp_portal.id)]})
+        # JobRad customization: The write statement would typically
+        # raise a validation error. For performance reasons, JobRad has
+        # deactivated the validation.
+        # with self.assertRaises(ValidationError):
+        #     grp_test.write({'implied_ids': [(4, self.grp_portal.id)]})
 
     def test_demote_user(self):
         """When a user is demoted to the status of portal/public,


### PR DESCRIPTION
Jobrad has customized the base module, removing a check for performance
reasons. This customization has caused one odoo unit test to fail. This
commit adapts the odoo test to reflect the jobrad behavior.

Description of the issue/feature this PR addresses:
Odoo test for base module is failing.

Current behavior before PR:
2022-08-01 09:08:28,866 473 INFO tests odoo.addons.base.tests.test_user_has_group: Starting TestHasGroup.test_two_user_types_implied_groups ...      
2022-08-01 09:08:28,930 473 INFO tests odoo.addons.base.tests.test_user_has_group: ====================================================================== 
2022-08-01 09:08:28,931 473 ERROR tests odoo.addons.base.tests.test_user_has_group: FAIL: TestHasGroup.test_two_user_types_implied_groups                                       
Traceback (most recent call last):                                                                                                                                                            
  File "/opt/odoo/odoo/addons/base/tests/test_user_has_group.py", line 181, in test_two_user_types_implied_groups                                        
    grp_test.write({'implied_ids': [(4, self.grp_portal.id)]})                                                                                                                                
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__                                                                                                                              
    next(self.gen)                                                                                                                                                                            
  File "/opt/odoo/odoo/tests/common.py", line 373, in _assertRaises                                                                                                                           
    yield cm                                                                                                                                                                                  
AssertionError: ValidationError not raised 

Desired behavior after PR is merged:
Tests are all green



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
