### PR TITLE
JRAD-853 set cookie lifetime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'jobrad-**'
+      - 'JRAD-**'
     tags:
       - 'jobrad-**'
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1440,7 +1440,7 @@ class Root(object):
         # - It could allow session fixation attacks.
         if not explicit_session and hasattr(response, 'set_cookie'):
             response.set_cookie(
-                'session_id', httprequest.session.sid, max_age=90 * 24 * 60 * 60, httponly=True)
+                'session_id', httprequest.session.sid, max_age=1 * 24 * 60 * 60, httponly=True)
 
         return response
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1439,8 +1439,14 @@ class Root(object):
         #   (the one using the cookie). That is a special feature of the Session Javascript class.
         # - It could allow session fixation attacks.
         if not explicit_session and hasattr(response, 'set_cookie'):
+            # breakpoint()
+            domain = httprequest.headers['Host']
+            if 'odoo' in domain:
+                print(f"****************** headers: {httprequest.headers} *********************")
+                domain = None
+            print(f"****************** domain: {domain} *********************")
             response.set_cookie(
-                'session_id', httprequest.session.sid, max_age=1 * 24 * 60 * 60, httponly=True)
+                    'session_id', httprequest.session.sid, max_age=1 * 24 * 60 * 60, httponly=True, domain=domain)
 
         return response
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
During pentesting it appeared that the max age of the session cookie was set to 90 days.
This should be reduced to lessen the risk of session takeover.

See https://jira.dev.jobrad.org/browse/JRAD-853

Current behavior before PR:
Cookie is set with an expiration date 90 days in the future.

Desired behavior after PR is merged:
Cookie is set with an expiration date 1 day in the future.

