### PR TITLE
Enable jupyter | uses code from: caburj (caburnay.joseph@gmail.com)

### DIFF
--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -53,7 +53,7 @@ class Console(code.InteractiveConsole):
 
 class Shell(Command):
     """Start odoo in an interactive shell"""
-    supported_shells = ['ipython', 'ptpython', 'bpython', 'python']
+    supported_shells = ['jupyter_kernel', 'ipython', 'ptpython', 'bpython', 'python']
 
     def init(self, args):
         config.parse_config(args)
@@ -86,6 +86,13 @@ class Shell(Command):
                     _logger.warning("Could not start '%s' shell." % shell)
                     _logger.debug("Shell error:", exc_info=True)
 
+    def jupyter_kernel(self, local_vars, jupyter_connection_file):
+        _logger.info('🪐🛸👽 LAUNCHING JUPYTER 👽🛸🪐')
+        for i in sorted(local_vars):
+            print('%s: %s' % (i, local_vars[i]))
+        from ipykernel.kernelapp import launch_new_instance
+        launch_new_instance(argv=['-f', jupyter_connection_file], user_ns=local_vars)
+
     def ipython(self, local_vars):
         from IPython import start_ipython
         start_ipython(argv=[], user_ns=local_vars)
@@ -101,7 +108,7 @@ class Shell(Command):
     def python(self, local_vars):
         Console(locals=local_vars).interact()
 
-    def shell(self, dbname):
+    def shell(self, dbname, jupyter_connection_file):
         local_vars = {
             'openerp': odoo,
             'odoo': odoo,
@@ -115,12 +122,20 @@ class Shell(Command):
                     env = odoo.api.Environment(cr, uid, ctx)
                     local_vars['env'] = env
                     local_vars['self'] = env.user
-                    self.console(local_vars)
+                    if jupyter_connection_file:
+                        self.jupyter_kernel(local_vars, jupyter_connection_file)
+                    else:
+                        self.console(local_vars)
                     cr.rollback()
             else:
                 self.console(local_vars)
 
     def run(self, args):
+        try:
+            i = args.index('-f')
+            jupyter_connection_file = args[i+1]
+        except ValueError:
+            jupyter_connection_file = None
         self.init(args)
-        self.shell(config['db_name'])
+        self.shell(config['db_name'], jupyter_connection_file)
         return 0

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -124,6 +124,7 @@ class configmanager(object):
 
         group.add_option("-D", "--data-dir", dest="data_dir", my_default=_get_default_datadir(),
                          help="Directory where to store Odoo data")
+        group.add_option("-f", "--connection-file", dest="connection_file")
         parser.add_option_group(group)
 
         # HTTP
@@ -515,6 +516,7 @@ class configmanager(object):
         self.options['demo'] = (dict(self.options['init'])
                                 if not self.options['without_demo'] else {})
         self.options['update'] = opt.update and dict.fromkeys(opt.update.split(','), 1) or {}
+        self.options['connection_file'] = opt.connection_file or ''
         self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()
 


### PR DESCRIPTION
Many thanks to @caburj for the logic to integrate jupyter with Odoo in this [PR](https://github.com/odoo/odoo/pull/34459/files).

# Detailed workflow of how using jupyter with Odoo will work

1. Start jupyter where Odoo is running
2. Open a new notebook or shell for a custom kernel that we still need to create. The specification will look like this:

    ```json
    {
     "argv": [
      "/usr/bin/python3", "/opt/odoo/odoo-bin", "shell",
      "-d", "some_database",
      "-f", "{connection_file}",
      # additional options of the odoo-cli
     ],
     "display_name": "my-custom-kernel",
     "language": "python",
     "metadata": {
      "debugger": true
     }
    }
    ```
    
    The `connection_file` variable is auto-populated by jupyter. This variable is very important:
    
    At runtime, when creating a notebook or a shell using a given "kernel template", jupyter creates a temporary file with additional configuration values (such as a port) in a `runtime` folder. This is what we call the **connection file**

3. The odoo-cli receives the option of the connection file from jupyter (autopopulated, as I mentioned before) it could look something like `-f kernel-54654646.json`. The CLI is able to receive this new option thanks to changes in `config.py`. 

4. We trickle down into `shell.py` where the new option `-f` will be parsed. On the presence of this new option (see line where we check it with `i = args.index('-f')`), we automatically know that it is jupyter and launch a new instance that attaches the connection file. If we do not do that, jupyter would not sync with Odoo and it would restart the shell command multiple times until it abandons, noticing that it cannot connect with the interpreter (disclaimer: not the best explanation, I'm not sure what exactly is happening in that particular case, just explaining what I experience).

5. Odoo works just like it would in a shell or in ipython, but now it's usable in notebooks :) !

# IMPORTANT NOTES

1. The changes have no impact on a "normal" run of Odoo (i.e. not in "shell model")
2. I have already tested various scenarios and found no issues, apart from debugging (but most likely I was doing it wrong, since I am very inexperienced with it). In fact it worked very smoothly, even with multiple notebooks using the new kernel.