### PR TITLE
Fix the cleanup of Ghostscript build directory in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,16 +33,18 @@ RUN curl -sL -o /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/re
 
 # ghostscript
 COPY docker/ghostscript_cmap_copyfix.diff /tmp/ghostscript_cmap_copyfix.diff
-RUN GHOSTSCRIPT_VERSION=10020 && GHOSTSCRIPT_FILE_NAME=ghostscript-10.02.0.tar.gz \
+RUN GHOSTSCRIPT_VERSION=10020 \
+    && GHOSTSCRIPT_FILE_NAME=ghostscript-10.02.0.tar.gz \
+    && GHOSTSCRIPT_BASE_NAME=$(basename ${GHOSTSCRIPT_FILE_NAME} .tar.gz) \
     && curl -sL -o /tmp/${GHOSTSCRIPT_FILE_NAME} https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${GHOSTSCRIPT_VERSION}/${GHOSTSCRIPT_FILE_NAME} \
     && tar -xzf /tmp/${GHOSTSCRIPT_FILE_NAME} -C /tmp \
-    && cd /tmp/$(basename ${GHOSTSCRIPT_FILE_NAME} .tar.gz)/ \
+    && cd /tmp/${GHOSTSCRIPT_BASE_NAME}/ \
     && patch -p1 < /tmp/ghostscript_cmap_copyfix.diff \
     && ./configure \
     && make \
     && make install \
     && ln -s /usr/local/bin/gs /usr/local/bin/ghostscript \
-    && rm -rf /tmp/${GHOSTSCRIPT_FILE_NAME} /tmp/$(basename ${GHOSTSCRIPT_FILE_NAME} .tar.gz})
+    && rm -rf /tmp/${GHOSTSCRIPT_FILE_NAME} /tmp/${GHOSTSCRIPT_BASE_NAME}
 
 # odoo directories
 RUN useradd -s /usr/sbin/nologin --create-home --password odoo odoo \


### PR DESCRIPTION
There is an extra right curly bracket after `.tar.gz` in the following line:
https://github.com/jobrad-gmbh/odoo/blob/31d2d9ef930ecb1d0d24a664af223322f04a2d88/docker/Dockerfile#L45
and the extensions don't actually get stripped. It causes the Ghostscript build directory not to be cleaned up and consequently the Docker image is ~345 MB larger than it should be.

This PR fixes the removal of the build directory.
