### PR TITLE
CPT-1 Use Ubuntu 22.04 LTS in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
-    libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 python3-magic git libffi-dev libc6 \
+    libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 git libffi-dev libc6 \
     libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev wkhtmltopdf \
     libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -64,7 +64,7 @@ RUN git clone --depth 1 -b v2.4.1 https://github.com/pyenv/pyenv.git "${PYENV_RO
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir setuptools --upgrade \
     && pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir -r /tmp/requirements.txt \
+    && pip3 install --no-cache-dir python-magic==0.4.27 -r /tmp/requirements.txt \
     && rm -rf /tmp/requirements.txt
 
 RUN apt-get purge -y build-essential

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ COPY docker/msfonts.sh /tmp/msfonts.sh
 RUN chmod +x /tmp/msfonts.sh; sync; /tmp/msfonts.sh; rm -rf /tmp/msfonts.sh
 
 # Python
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.8.10
 ENV PYENV_ROOT="$HOME/.pyenv"
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN git clone --depth 1 -b v2.4.1 https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ ARG PYTHON_VERSION=3.8.10
 ENV PYENV_ROOT="$HOME/.pyenv"
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 RUN git clone --depth 1 -b v2.4.1 https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" \
-    && pyenv install ${PYTHON_VERSION} \
+    && pyenv install --verbose ${PYTHON_VERSION} \
     && pyenv global ${PYTHON_VERSION}
 
 # pip dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # variables & locales
 ENV TZ=Europe/Berlin
@@ -21,15 +21,10 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
-    libldap2-dev libssl-dev poppler-utils ttf-dejavu cabextract libfreetype6 python3-magic git libffi-dev libc6 \
-    libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev \
+    libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 python3-magic git libffi-dev libc6 \
+    libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev wkhtmltopdf \
+    libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# wkhtmltopdf
-RUN curl -sL -o /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb \
-    && echo 'ae4e85641f004a2097621787bf4381e962fb91e1 /tmp/wkhtmltox.deb' | sha1sum -c - \
-    && apt-get install -y --no-install-recommends /tmp/wkhtmltox.deb \
-    && rm -rf /tmp/wkhtmltox.deb
 
 # ghostscript
 COPY docker/ghostscript_cmap_copyfix.diff /tmp/ghostscript_cmap_copyfix.diff
@@ -47,7 +42,8 @@ RUN GHOSTSCRIPT_VERSION=10020 \
     && rm -rf /tmp/${GHOSTSCRIPT_FILE_NAME} /tmp/${GHOSTSCRIPT_BASE_NAME}
 
 # odoo directories
-RUN useradd -s /usr/sbin/nologin --create-home --password odoo odoo \
+RUN userdel -r ubuntu \
+  && useradd -s /usr/sbin/nologin --create-home --password odoo odoo \
   && mkdir /home/odoo/.local \
   && chown odoo:odoo /home/odoo/.local \
   && mkdir --parents /opt/odoo/tests \
@@ -56,6 +52,14 @@ RUN useradd -s /usr/sbin/nologin --create-home --password odoo odoo \
 # msfonts
 COPY docker/msfonts.sh /tmp/msfonts.sh
 RUN chmod +x /tmp/msfonts.sh; sync; /tmp/msfonts.sh; rm -rf /tmp/msfonts.sh
+
+# Python
+ARG PYTHON_VERSION=3.8
+ENV PYENV_ROOT="$HOME/.pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+RUN git clone --depth 1 -b v2.4.1 https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" \
+    && pyenv install ${PYTHON_VERSION} \
+    && pyenv global ${PYTHON_VERSION}
 
 # pip dependencies
 COPY requirements.txt /tmp/requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates tzdata \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
     libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 git libffi-dev libc6 \
-    libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev \
+    libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev node-less libpq-dev \
     libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -70,7 +70,7 @@ RUN git clone --depth 1 -b v2.4.1 https://github.com/pyenv/pyenv.git "${PYENV_RO
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir setuptools --upgrade \
     && pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir python-magic==0.4.27 -r /tmp/requirements.txt \
+    && pip3 install --no-cache-dir python-magic==0.4.27 cairocffi==0.9.0 -r /tmp/requirements.txt \
     && rm -rf /tmp/requirements.txt
 
 RUN apt-get purge -y build-essential

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
     libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 git libffi-dev libc6 \
     libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev node-less libpq-dev \
-    libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # wkhtmltopdf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN git clone --depth 1 -b v2.4.1 https://github.com/pyenv/pyenv.git "${PYENV_RO
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir setuptools --upgrade \
     && pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir python-magic==0.4.27 cairocffi==0.9.0 -r /tmp/requirements.txt \
+    && pip3 install --no-cache-dir -r /tmp/requirements.txt \
     && rm -rf /tmp/requirements.txt
 
 RUN apt-get purge -y build-essential

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL en_US.UTF-8
 
 # dependencies for odoo or python packages
 RUN apt-get update -qq \
-    && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates tzdata \
+    && apt-get install -y --no-install-recommends libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates tzdata \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
     libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 git libffi-dev libc6 \
     libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev node-less libpq-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL en_US.UTF-8
 
 # dependencies for odoo or python packages
 RUN apt-get update -qq \
-    && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates \
+    && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates tzdata \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
     libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 git libffi-dev libc6 \
     libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev wkhtmltopdf \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 # variables & locales
 ENV TZ=Europe/Berlin
@@ -42,8 +42,7 @@ RUN GHOSTSCRIPT_VERSION=10020 \
     && rm -rf /tmp/${GHOSTSCRIPT_FILE_NAME} /tmp/${GHOSTSCRIPT_BASE_NAME}
 
 # odoo directories
-RUN userdel -r ubuntu \
-  && useradd -s /usr/sbin/nologin --create-home --password odoo odoo \
+RUN useradd -s /usr/sbin/nologin --create-home --password odoo odoo \
   && mkdir /home/odoo/.local \
   && chown odoo:odoo /home/odoo/.local \
   && mkdir --parents /opt/odoo/tests \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,15 @@ RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends python3 python3-pip python3-dev libjpeg-dev libsasl2-dev libxslt-dev libxml2-dev ca-certificates tzdata \
     curl file xfonts-75dpi xfonts-base unzip build-essential fontconfig libfontconfig1 libpng16-16 \
     libldap2-dev libssl-dev poppler-utils fonts-dejavu cabextract libfreetype6 git libffi-dev libc6 \
-    libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev wkhtmltopdf \
+    libstdc++6 lib32z1 libpoppler-cpp-dev pkg-config librdkafka-dev python3-cairocffi node-less libpq-dev \
     libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# wkhtmltopdf
+RUN curl -sL -o /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb \
+    && echo '800eb1c699d07238fee77bf9df1556964f00ffcf /tmp/wkhtmltox.deb' | sha1sum -c - \
+    && apt-get install -y --no-install-recommends /tmp/wkhtmltox.deb \
+    && rm -rf /tmp/wkhtmltox.deb
 
 # ghostscript
 COPY docker/ghostscript_cmap_copyfix.diff /tmp/ghostscript_cmap_copyfix.diff

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,5 @@ xlwt==1.3.*
 xlrd==1.1.0; python_version < '3.8'
 xlrd==1.2.0; python_version >= '3.8'
 pypiwin32 ; sys_platform == 'win32'
+python-magic==0.4.27
+cairocffi==0.9.0


### PR DESCRIPTION
### Changes
- `ttf-dejavu` package has been renamed to `fonts-dejavu`
- `tzdata` package is not installed by default so it is installed manually
- `wkhtmltopdf`
  - Currently used Debian package (`0.12.5`) cannot be installed because it depends on old `libssl`
  - We use the latest version packaged by original authors (`0.12.6`) which is at the same time the latest version available since the project is not maintained any more
  - We didn't install the same version packaged by Ubuntu because that one is not using patched Qt which provides CLI flags that we depend on
- Python
  - Ubuntu `22.04 LTS` comes with Python `3.10`
  - Current `odoo` dependencies do not compile from Python `3.10` onward either because of Cython version changes or Python C API changes
  - We use [pyenv](https://github.com/pyenv/pyenv) to keep the current Python version which is `3.8`
    - Some additional development system libraries are installed because Python is built from source
    - This also complies with new policy of Debian-based distributions to avoid installing system-wide Python dependencies in order to avoid breaking system packages (alternative is to use `pip --break-system-packages`)
  - APT's `python3-magic` was replaced with pip's `python-magic`
  - APT's `python3-cairocffi` was replaced with pip's `cairocffi`
- Decreased Docker image size from `2.03` to `1.83` GB

### Future notes
- Explicitly delete `ubuntu` user
  - The new Ubuntu `24.04 LTS` image comes with `ubuntu` user (`uid=1000`)
  - We should remove the `ubuntu` user since it is not needed and causes trouble with permissions when mounting sources into a dev container
  - That way `odoo` user gets to have `uid=1000`
- `wkhtmltopdf` will have to be compiled from source (good luck 🍀) 