### PR TITLE
CPT-127 Make list of attachments accessible again

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -488,14 +488,14 @@ class IrAttachment(models.Model):
             args.insert(0, ('res_field', '=', False))
 
         ids = super(IrAttachment, self)._search(args, offset=offset, limit=limit, order=order,
-                                                count=False, access_rights_uid=access_rights_uid)
+                                                count=count, access_rights_uid=access_rights_uid)
 
-        if self.env.is_superuser():
+        if count or self.env.is_superuser():
             # rules do not apply for the superuser
-            return len(ids) if count else ids
+            return ids
 
         if not ids:
-            return 0 if count else []
+            return []
 
         # Work with a set, as list.remove() is prohibitive for large lists of documents
         # (takes 20+ seconds on a db with 100k docs during search_count()!)
@@ -552,7 +552,7 @@ class IrAttachment(models.Model):
                                        limit=limit, order=order, count=count,
                                        access_rights_uid=access_rights_uid)[:limit - len(result)])
 
-        return len(result) if count else list(result)
+        return list(result)
 
     def _read(self, fields):
         self.check('read')


### PR DESCRIPTION
When opening the list of attachments, Odoo wants to display the total number of items in the list. This is displayed in the top right such as "1 - 80 of 2264".

In order to display the total number, Odoo fetches all IDs and filters out the ids to which the user does not have access. For the JobRad database with more than 32 million entries this causes either a MemoryError or a timeout.

The suggested solution is to skip the filtering. This means the total number of entries will be wrong. The list can still be navigated without any issues.