### PR TITLE
JRAD-2654 Create workflow for OWASP Dependency Check

### DIFF
--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -1,0 +1,51 @@
+name: OWASP Dependency Check
+
+on:
+  schedule:
+    - cron: '00 4 * * *'
+  workflow_dispatch:
+    # Inputs when the workflow is triggered manually.
+    inputs:
+      scan_path:
+          description: 'Path to scan'
+          default: '.'
+          required: true
+          type: string
+      format:
+        description: 'Report format'
+        default: 'HTML'
+        required: true
+        type: choice
+        options:
+          - HTML
+          - XML
+          - CSV
+          - JSON
+          - JUNIT
+          - SARIF
+          - JENKINS
+          - GITLAB
+          - ALL
+
+jobs:
+  depchecktest:
+    runs-on: ubuntu-latest
+    name: depecheck_test
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Depcheck
+        uses: dependency-check/Dependency-Check_Action@main
+        id: Depcheck
+        with:
+          project: 'Odoo'
+          path: ${{ inputs.scan_path || '.' }}
+          format: ${{ inputs.format || 'HTML' }}     
+          out: 'reports'
+          args: >
+            --enableExperimental
+      - name: Upload Test results
+        uses: actions/upload-artifact@master
+        with:
+           name: Depcheck report
+           path: ${{github.workspace}}/reports


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Create a workflow that runs [OWASP Dependency Check](https://jeremylong.github.io/DependencyCheck/dependency-check-cli/index.html), which is a tool that makes an analysis of security issues in the dependencies, covering Javascript, Node and Python* dependencies, among others.
The workflow runs every day, but also can be triggered manually. The report can be downloaded from each run of the workflow in the Github Actions tab.
The source code of the action that runs the Dependency Check is here: https://github.com/dependency-check/Dependency-Check_Action

**Current behavior before PR:**
No security check of JS dependencies

**Desired behavior after PR is merged:**
Javascript (and Python*) dependencies are checked daily and also manually when desired
A report is generated in each workflow execution, shown in the Actions tab. The report can be downloading after clicking in the workflow execution.

*Python dependencies are checked by Dependency Check using experimental analyzers. Removing --enableExperimental argument from the Depcheck step in the workflow will disable the Python analyzer.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
