### PR TITLE
CPT-218 Include enterprise addons in the ARM image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,17 @@ jobs:
     env:
       GHCR_IMAGE_NAME: ghcr.io/jobrad-gmbh/odoo
     steps:
-    - uses: actions/checkout@v3
+    - name: Clone
+      uses: actions/checkout@v3
+
+    - name: Clone enterprise addons
+      uses: actions/checkout@v3
+      with:
+        repository: jobrad-gmbh/odoo-addons-enterprise
+        ref: 14.0.10
+        token: ${{ secrets.ODOO_REPO_TOKEN }}
+        path: addons_enterprise
+        fetch-depth: 1
 
     - name: Create variables
       shell: bash


### PR DESCRIPTION
Description of the issue/feature this PR addresses: The Odoo enterprise addons should be added to the Odoo's base image, to be included in the images built based on it.

Current behavior before PR: The enterprise addons are not included in the ARM image.

Desired behavior after PR is merged: The Docker image build process for the ARM image will include the enterprise addons.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
