### PR TITLE
CPT-608 Get rid of deprecation warnings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -142,7 +142,7 @@ jobs:
 
   test:
     runs-on: self-hosted
-    needs: combine-docker
+    needs: [build-docker, combine-docker]
     steps:
       - uses: actions/checkout@v4
 
@@ -156,6 +156,10 @@ jobs:
       - name: Run base Odoo tests
         run: |
           export ODOO_IMAGE=${{ needs.build-docker.outputs.IMAGE }}
+          if [ -z "$ODOO_IMAGE" ]; then
+            echo "ODOO_IMAGE is empty!"
+            exit 1
+          fi
           ./tests/run_tests.sh tests/modules
 
       - name: Cleanup

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -12,7 +12,7 @@ import requests
 from lxml import etree, html
 from psycopg2 import sql
 from werkzeug import urls
-from werkzeug.datastructures import OrderedMultiDict
+from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import NotFound
 
 from odoo import api, fields, models, tools, http, release, registry
@@ -1391,10 +1391,10 @@ class Website(models.Model):
     def _is_canonical_url(self, canonical_params):
         """Returns whether the current request URL is canonical."""
         self.ensure_one()
-        # Compare OrderedMultiDict because the order is important, there must be
+        # Compare MultiDict (ordered) because the order is important, there must be
         # only one canonical and not params permutations.
         params = request.httprequest.args
-        canonical_params = canonical_params or OrderedMultiDict()
+        canonical_params = canonical_params or MultiDict()
         if params != canonical_params:
             return False
         # Compare URL at the first rerouting iteration (if available) because

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
-from werkzeug.datastructures import OrderedMultiDict
+from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import NotFound
 
 from odoo import fields, http, _
@@ -128,7 +128,7 @@ class WebsiteEventController(http.Controller):
 
         if searches['date'] == 'old':
             # the only way to display this content is to set date=old so it must be canonical
-            values['canonical_params'] = OrderedMultiDict([('date', 'old')])
+            values['canonical_params'] = MultiDict([('date', 'old')])
 
         return request.render("website_event.index", values)
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1203,7 +1203,7 @@ class HTTPRequest:
     def __init__(self, environ):
         httprequest = werkzeug.wrappers.Request(environ)
         httprequest.user_agent_class = UserAgent  # use vendored userAgent since it will be removed in 2.1
-        httprequest.parameter_storage_class = werkzeug.datastructures.ImmutableOrderedMultiDict
+        httprequest.parameter_storage_class = werkzeug.datastructures.ImmutableMultiDict
 
         self.__wrapped = httprequest
         self.__environ = self.__wrapped.environ


### PR DESCRIPTION
- The usage of deprecated `OrderedMultiDict` and `ImmutableOrderedMultiDict` from Werkzeug is replaced with `MultiDict` and `ImmutableMultiDict`