### PR TITLE
CPT-666 Remove __future__ usages in core Odoo after CVE-2025-50817

### DIFF
--- a/addons/hw_escpos/controllers/main.py
+++ b/addons/hw_escpos/controllers/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from __future__ import print_function
 import logging
 import math
 import os

--- a/addons/hw_escpos/escpos/escpos.py
+++ b/addons/hw_escpos/escpos/escpos.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
 import base64
 import copy
 import io

--- a/addons/hw_escpos/escpos/printer.py
+++ b/addons/hw_escpos/escpos/printer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function
 import serial
 import socket
 import usb.core

--- a/doc/cla/stats.py
+++ b/doc/cla/stats.py
@@ -2,7 +2,6 @@
 #
 # Runme From the repo toplevel directory
 #
-from __future__ import print_function
 import subprocess
 import glob
 import re

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from textwrap import dedent
 import copy
 import io

--- a/odoo/addons/test_testing_utilities/models.py
+++ b/odoo/addons/test_testing_utilities/models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
-
 from itertools import count, zip_longest
 
 from odoo import api, fields, models, Command

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 import sys
 import os

--- a/odoo/cli/deploy.py
+++ b/odoo/cli/deploy.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import argparse
 import os
 import requests

--- a/odoo/cli/scaffold.py
+++ b/odoo/cli/scaffold.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import argparse
 import os
 import re

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from __future__ import print_function
 import code
 import logging
 import os

--- a/odoo/cli/start.py
+++ b/odoo/cli/start.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import argparse
 import glob
 import itertools

--- a/odoo/tools/_monkeypatches_urls.py
+++ b/odoo/tools/_monkeypatches_urls.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 import os
 import sys
@@ -6,6 +5,7 @@ import re
 import typing as t
 import warnings
 from werkzeug.datastructures import iter_multi_items
+import werkzeug.datastructures as ds
 from werkzeug.urls import _decode_idna
 
 import operator
@@ -98,13 +98,13 @@ class BaseURL(_URLTuple):
     _lbracket: str
     _rbracket: str
 
-    def __new__(cls, *args: t.Any, **kwargs: t.Any) -> BaseURL:
+    def __new__(cls, *args: t.Any, **kwargs: t.Any) -> "BaseURL":
         return super().__new__(cls, *args, **kwargs)
 
     def __str__(self) -> str:
         return self.to_url()
 
-    def replace(self, **kwargs: t.Any) -> BaseURL:
+    def replace(self, **kwargs: t.Any) -> "BaseURL":
         """Return an URL with the same values, except for those parameters
         given new values by whichever keyword arguments are specified."""
         return self._replace(**kwargs)
@@ -193,7 +193,7 @@ class BaseURL(_URLTuple):
         """
         return url_decode(self.query, *args, **kwargs)
 
-    def join(self, *args: t.Any, **kwargs: t.Any) -> BaseURL:
+    def join(self, *args: t.Any, **kwargs: t.Any) -> "BaseURL":
         """Joins this URL with another one.  This is just a convenience
         function for calling into :meth:`url_join` and then parsing the
         return value again.
@@ -370,7 +370,7 @@ class URL(BaseURL):
     _lbracket = "["
     _rbracket = "]"
 
-    def encode(self, charset: str = "utf-8", errors: str = "replace") -> BytesURL:
+    def encode(self, charset: str = "utf-8", errors: str = "replace") -> "BytesURL":
         """Encodes the URL to a tuple made out of bytes.  The charset is
         only being used for the path, query and fragment.
         """
@@ -405,7 +405,7 @@ class BytesURL(BaseURL):
         """Returns the netloc unchanged as bytes."""
         return self.netloc  # type: ignore
 
-    def decode(self, charset: str = "utf-8", errors: str = "replace") -> URL:
+    def decode(self, charset: str = "utf-8", errors: str = "replace") -> "URL":
         """Decodes the URL to a tuple made out of strings.  The charset is
         only being used for the path, query and fragment.
         """
@@ -493,7 +493,7 @@ def _url_unquote_legacy(value: str, unsafe: str = "") -> str:
 
 def url_parse(
     url: str, scheme: str | None = None, allow_fragments: bool = True
-) -> BaseURL:
+) -> "BaseURL":
     """Parses a URL from a string into a :class:`URL` tuple.  If the URL
     is lacking a scheme it can be provided as second argument. Otherwise,
     it is ignored.  Optionally fragments can be stripped from the URL

--- a/odoo/tools/appdirs.py
+++ b/odoo/tools/appdirs.py
@@ -7,7 +7,6 @@
 
 See <http://github.com/ActiveState/appdirs> for details and usage.
 """
-from __future__ import print_function
 # Dev Notes:
 # - MSDN on where to store app data files:
 #   http://support.microsoft.com/default.aspx?scid=kb;en-us;310294#XSLTH3194121123120121120120

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from __future__ import print_function
 import builtins
 import math
 

--- a/odoo/tools/parse_version.py
+++ b/odoo/tools/parse_version.py
@@ -4,7 +4,6 @@
 ## this functions are taken from the setuptools package (version 0.6c8)
 ## http://peak.telecommunity.com/DevCenter/PkgResources#parsing-utilities
 
-from __future__ import print_function
 import re
 
 component_re = re.compile(r'(\d+ | [a-z]+ | \.| -)', re.VERBOSE)


### PR DESCRIPTION
**CVE-2025-50817** highlights a severe vulnerability through the usage of the python-future module.

`from __future__ import [...]` is used in several places in base `odoo`, as well as in `odoo-addons-jobrad`.
This PR addresses the usages in JobRad's base Odoo fork. 
Generally, we want to keep the changes of our Odoo fork from base Odoo to a minumum. Nevertheless, we decided to remove all the usages of `__future__` module to mitigate the effects of the CVE. 

As we currently run Odoo on `python3.11`, most functionality provided by` __future__` is now mandatory in python > 3.x.
Solely `from __future__ import annotations` still is not mandatory. Therefore, the corresponding code is changed and the `__future__` import removed for all cases. 