### PR TITLE
chore: replace self-hosted runners with ubuntu-24.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: self-hosted
+          - runner: ubuntu-24.04
             platform: linux/amd64
             suffix: amd64
           - runner: Linux-ARM64-2C-8GB
@@ -108,7 +108,7 @@ jobs:
         provenance: false
 
   combine-docker:
-    runs-on: [self-hosted, short]
+    runs-on: ubuntu-24.04
     needs: [build-docker]
     permissions:
       contents: read
@@ -141,7 +141,7 @@ jobs:
           push: true
 
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     needs: [build-docker, combine-docker]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
artifactory.service.jobrad.org is now public, so self-hosted runners are no longer needed to access the artifactory.

Have a look at [Teams](https://teams.cloud.microsoft/l/message/19:ee34f803e111426cae47e999b5dc37f9@thread.tacv2/1771424189167?tenantId=3af5034c-ce4c-4e09-8472-369a58ca96e1&groupId=8077b4d5-98d6-4615-ae01-c2f79fe2177b&parentMessageId=1771424189167&teamName=JR-PTO%20Gesamt&channelName=Software%20Engineering&createdTime=1771424189167) to get some more context.

This pull request is not mandatory, we want it to make it as easy as possible for you to migrate.