### PR TITLE
RNR-493 Bump version number of base module

### DIFF
--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Base',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Hidden',
     'description': """
 The kernel of Odoo, needed for all installation.


### PR DESCRIPTION
We need to bump the version number of the base module to trigger a migration script. The alternative option would have been to increase the minor version number of Odoo.

Do not cherry-pick this commit to branches for future Odoo versions. Odoo prefixes the module version with the current series. Thus, 1.4 will become 15.0.1.4. Thus, not applying this commit to jobrad-16.0 branch means migrating from 15.0.1.4 to 16.0.1.3

Starting with Odoo 16.0 we can use --pre-upgrade-scripts command line option.

https://github.com/jobrad-gmbh/odoo/pull/75
